### PR TITLE
Fix spelling mistake in loading div class name

### DIFF
--- a/src/GooglePlacesAutocomplete/index.js
+++ b/src/GooglePlacesAutocomplete/index.js
@@ -214,7 +214,7 @@ class GooglePlacesAutocomplete extends Component {
 
     return (
       <div className="google-places-autocomplete__suggestions-container">
-        <div className="google-places-autcomplete__suggestions">
+        <div className="google-places-autocomplete__suggestions">
           Loading...
         </div>
       </div>


### PR DESCRIPTION
The word autocomplete is missing an o

Couldn't work out why my CSS wasn't being applied for ages!