### PR TITLE
Remove script only if it was injected before

### DIFF
--- a/src/helpers/injectScript.js
+++ b/src/helpers/injectScript.js
@@ -12,5 +12,7 @@ export const injectScript = (apiKey) => {
 
 export const removeScript = () => {
   const script = document.getElementById(SCRIPT_ID);
-  document.body.removeChild(script);
+  if (script) {
+    document.body.removeChild(script);
+  }
 };


### PR DESCRIPTION
When unmounting the component, it will throw an error when the script has not been injected before.