### PR TITLE
Adding displayFromSuggestionSelected

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ export default Component;
 | inputStyle            | object   |          | {}         |
 | loader                | node     |          | null       |
 | onSelect              | function |          | () => {}   |
+| displayFromSuggestionSelected | function |          | `(suggestion) => ( suggestion.description )`   |
 | placeholder           | string   |          | 'Address'  |
 | renderInput           | function |          | undefined  |
 | renderSuggestions     | function |          | undefined  |
@@ -180,7 +181,7 @@ import loader from '../assets/loader.svg';
 
 ### onSelect
 
-Function to be called when the user select one of the suggestions provided by Google Maps API.
+Function to be called when the user selects one of the suggestions provided by Google Maps API.
 
 Example:
 ```js
@@ -189,6 +190,23 @@ Example:
   <GooglePlacesAutocomplete
     onSelect={({ description }) => (
       this.setState({ address: description });
+    )}
+  />
+
+...
+```
+
+### displayFromSuggestionSelected
+
+Function to be called when the user selects one of the suggestions provided by Google Maps API. The function receives a suggestion object as a parameter and returns a string to update the input value.
+
+Example:
+```js
+...
+
+  <GooglePlacesAutocomplete
+    displayFromSuggestionSelected={({ structured_formatting }) => (
+      structured_formatting.main_text
     )}
   />
 

--- a/src/GooglePlacesAutocomplete/index.js
+++ b/src/GooglePlacesAutocomplete/index.js
@@ -126,12 +126,12 @@ class GooglePlacesAutocomplete extends React.Component {
   onSuggestionSelect = (suggestion, ev = null) => {
     if (ev) ev.stopPropagation();
 
-    const { onSelect } = this.props;
+    const { displayFromSuggestionSelected, onSelect } = this.props;
 
     this.setState({
       activeSuggestion: null,
       suggestions: [],
-      value: suggestion.description,
+      value: displayFromSuggestionSelected(suggestion),
     });
 
     this.generateSessionToken();
@@ -337,6 +337,7 @@ GooglePlacesAutocomplete.propTypes = {
   inputStyle: PropTypes.object,
   loader: PropTypes.node,
   onSelect: PropTypes.func,
+  displayFromSuggestionSelected: PropTypes.func,
   placeholder: PropTypes.string,
   renderInput: PropTypes.func,
   renderSuggestions: PropTypes.func,
@@ -357,6 +358,7 @@ GooglePlacesAutocomplete.defaultProps = {
   inputStyle: {},
   loader: null,
   onSelect: () => { },
+  displayFromSuggestionSelected: (suggestion) => (suggestion.description),
   placeholder: 'Address...',
   renderInput: undefined,
   renderSuggestions: undefined,


### PR DESCRIPTION
### Changes done
- Adding displayFromSuggestionSelected optional prop
- Updating the docs accordingly

### Use case
When the user selects a suggestion the input value it's updated with the suggestion description text. The limitation around this is that the developer is not allowed to change what is displayed in the input value.
With the addition of this PR the developer could set a prop to customize this behavior and use, for example, other parts of the suggestion object such ad only the main part of the suggestion selected as is documented in the parts I added to the documentation:

```js
  <GooglePlacesAutocomplete
    displayFromSuggestionSelected={({ structured_formatting }) => (
      structured_formatting.main_text
    )}
  />
``` 