### PR TITLE
Fix function spelling and invalid reference

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-google-places-autocomplete",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-google-places-autocomplete",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "Google places autocomplete input for ReactJS.",
   "main": "dist/react-google-places-autocomplete.cjs.js",
   "module": "dist/react-google-places-autocomplete.esm.js",


### PR DESCRIPTION
Function `initalizeService` was misspelled. Three references to the function used the incorrect spelling, but one reference was using the correct spelling.  Fixed issue by changing function and valid references to use correct spelling.