### PR TITLE
Adding minLengthAutocomplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ export default Component;
 | suggestionsClassNames | shape    |          | `{ container: '', suggestion: '', suggestionActive: '' }` |
 | suggestionsStyles     | shape    |          | `{ container: {}, suggestion: {} }` |
 | withSessionToken      | boolean  |          | false      |
+| minLengthAutocomplete | number   |          | 0          |
 
 
 ### apiKey
@@ -318,6 +319,10 @@ This is needed when you want to render more than one autocomplete input on the s
 ### withSessionToken
 
 If this prop is `true`, the component will handle changing the `sessionToken` on every session. To learn more about how this works refer to [Google Places Session Token docs](https://developers.google.com/places/web-service/session-tokens).
+
+### minLengthAutocomplete
+
+Defines a minimum number of characters to make requests to the Google API
 
 ## Utility Functions
 

--- a/src/GooglePlacesAutocomplete/index.js
+++ b/src/GooglePlacesAutocomplete/index.js
@@ -114,9 +114,10 @@ class GooglePlacesAutocomplete extends React.Component {
   }
 
   changeValue = (value) => {
+    const { minLengthAutocomplete } = this.props;
     this.setState({ value });
 
-    if (value.length > 0) {
+    if (value.length > minLengthAutocomplete) {
       this.fetchSuggestions(value);
     } else {
       this.setState({ suggestions: [] });
@@ -345,6 +346,7 @@ GooglePlacesAutocomplete.propTypes = {
   suggestionsClassNames: suggestionClassNamesType,
   suggestionsStyles: suggestionStylesType,
   withSessionToken: PropTypes.bool,
+  minLengthAutocomplete: PropTypes.number,
 };
 
 GooglePlacesAutocomplete.defaultProps = {
@@ -373,6 +375,7 @@ GooglePlacesAutocomplete.defaultProps = {
     suggestion: {},
   },
   withSessionToken: false,
+  minLengthAutocomplete: 0,
 };
 
 export default GooglePlacesAutocomplete;


### PR DESCRIPTION
Through this property it is possible to define a minimum number of characters for Google Autocomplete to start running, being possible to optimize the use of the API.