### PR TITLE
Improve script injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ export default Component;
 | inputClassName        | string   |          | ''         |
 | inputStyle            | object   |          | {}         |
 | loader                | node     |          | null       |
+| onLoadFailed          | function |          | `console.error` |
 | onSelect              | function |          | () => {}   |
 | displayFromSuggestionSelected | function |          | `(suggestion) => ( suggestion.description )`   |
 | placeholder           | string   |          | 'Address'  |
@@ -191,6 +192,23 @@ Example:
   <GooglePlacesAutocomplete
     onSelect={({ description }) => (
       this.setState({ address: description });
+    )}
+  />
+
+...
+```
+
+### onLoadFailed
+
+Function to be called when the injection of the Google API script fails due to network error.
+
+Example:
+```js
+...
+
+  <GooglePlacesAutocomplete
+    onLoadFailed={(error) => (
+      console.error("Could not inject Google script", error);
     )}
   />
 

--- a/src/helpers/injectScript.js
+++ b/src/helpers/injectScript.js
@@ -1,15 +1,81 @@
-const SCRIPT_ID = 'react-google-places-autocomplete';
+const INJECTION_STATE_NOT_YET = 'not yet';
+const INJECTION_STATE_IN_PROGRESS = 'in progress';
+const INJECTION_STATE_DONE = 'done';
 
+let injectionState = INJECTION_STATE_NOT_YET;
+let injectionError = null;
+
+let onScriptLoadCallbacks = [];
+let onScriptLoadErrorCallbacks = [];
+
+// Returns a promise that resolves
+//   - when the script becomes available or
+//   - immediately, if the script had already been injected due to a prior call.
+//
+// The promise is rejected in case the injection fails (e.g. due to a network
+// error).
+//
+// Note that only the first call of the function will actually trigger an
+// injection with the provided API key, the subsequent calls will be
+// resolved/rejected when the first one succeeds/fails.
 const injectScript = (apiKey) => {
-  if (document.getElementById(SCRIPT_ID)) return;
+  switch (injectionState) {
+    case INJECTION_STATE_DONE:
 
-  const script = document.createElement('script');
+      return injectionError ? Promise.reject(injectionError) : Promise.resolve();
 
-  script.id = SCRIPT_ID;
-  script.type = 'text/javascript';
-  script.src = `https://maps.googleapis.com/maps/api/js?key=${apiKey}&libraries=places`;
+    case INJECTION_STATE_IN_PROGRESS:
 
-  document.body.appendChild(script);
+      return new Promise((resolve, reject) => {
+        onScriptLoadCallbacks.push(resolve);
+        onScriptLoadErrorCallbacks.push(reject);
+      });
+
+    default: // INJECTION_STATE_NOT_YET
+
+      injectionState = INJECTION_STATE_IN_PROGRESS;
+
+      return new Promise((resolve, reject) => {
+        const script = document.createElement('script');
+
+        script.type = 'text/javascript';
+        script.src = `https://maps.googleapis.com/maps/api/js?key=${apiKey}&libraries=places`;
+        script.async = true;
+        script.defer = true;
+
+        const onScriptLoad = () => {
+          // Resolve current promise
+          resolve();
+          // Resolve the pending promises in their respective order
+          onScriptLoadCallbacks.forEach((cb) => cb());
+
+          cleanup();
+        };
+        const onScriptLoadError = () => {
+          // Reject all promises with this error
+          injectionError = new Error('[react-google-places-autocomplete] Could not inject Google script');
+          // Reject current promise with the error
+          reject(injectionError);
+          // Reject all pending promises in their respective order with the error
+          onScriptLoadErrorCallbacks.forEach((cb) => cb(injectionError));
+
+          cleanup();
+        };
+
+        // Release callbacks and unregister listeners
+        const cleanup = () => {
+          script.removeEventListener('load', onScriptLoad);
+          script.removeEventListener('error', onScriptLoadError);
+          onScriptLoadCallbacks = [];
+          onScriptLoadErrorCallbacks = [];
+        };
+
+        script.addEventListener('load', onScriptLoad);
+        script.addEventListener('error', onScriptLoadError);
+
+        document.body.appendChild(script);
+      });
+  }
 };
 
 export default injectScript;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -41,6 +41,7 @@ interface GooglePlacesAutocompleteProps {
   inputStyle?: object;
   loader?: JSX.Element;
   minLengthAutocomplete?: number;
+  onLoadFailed?: (error: Error) => void;
   onSelect?: (selection: any) => void;
   placeholder?: string;
   renderInput?: (props: any) => JSX.Element;


### PR DESCRIPTION
This PR aims to solve issue #62 as an alternative to PR #64 

The current implementation injects the Google scripts, if the `apiKey` attribute is provided to a `GooglePlacesAutocomplete` component. After the injection, the component starts polling whether the scripts have been loaded by examining the `window.google.maps.places` global variable. In case the script is not ready yet, an error message is printed to the console (potentially several times), even though it might be an expected behavior. On the other hand, there is no way to catch actual injection errors.

The proposed implementation prints an error message only when an error actually occurs and also brings in the following advantages:
- Uses callbacks instead of polling
- The errors are transparent to parent components, so that they can catch and handle it
- Can handle concurrent script injections, meaning that all of them will either succeed or fail

These changes are intended to be 100% backward compatible and bring in no new dependency.

Let me know, what you think!