### PR TITLE
Exposed the onchange event to enable users text changes to be saved

### DIFF
--- a/src/GooglePlacesAutocomplete/index.js
+++ b/src/GooglePlacesAutocomplete/index.js
@@ -114,7 +114,8 @@ class GooglePlacesAutocomplete extends React.Component {
   }
 
   changeValue = (value) => {
-    const { minLengthAutocomplete } = this.props;
+    const { minLengthAutocomplete, onTextChange } = this.props;
+    onTextChange(value || '')
     this.setState({ value });
 
     if (value.length > minLengthAutocomplete) {
@@ -347,6 +348,7 @@ GooglePlacesAutocomplete.propTypes = {
   suggestionsStyles: suggestionStylesType,
   withSessionToken: PropTypes.bool,
   minLengthAutocomplete: PropTypes.number,
+  onTextChange: PropTypes.func
 };
 
 GooglePlacesAutocomplete.defaultProps = {
@@ -376,6 +378,7 @@ GooglePlacesAutocomplete.defaultProps = {
     suggestion: {},
   },
   withSessionToken: false,
+  onTextChange: () => {}
 };
 
 export default GooglePlacesAutocomplete;


### PR DESCRIPTION
I have a use case where I need to be able to also capture if the user makes a change to the autocompleted text. 

IMO it feels super clunky when the user makes changes/customisations to the auto-filled text and they aren't captured even though they show in the text field.

I have exposed the on change event as a prop as onTextChange which gets called in the changeValue function. There is also an empty default set in the defaultProps to maintain comparability.