### PR TITLE
Fix script injection bug

### DIFF
--- a/src/helpers/injectScript.js
+++ b/src/helpers/injectScript.js
@@ -68,6 +68,7 @@ const injectScript = (apiKey) => {
           script.removeEventListener('error', onScriptLoadError);
           onScriptLoadCallbacks = [];
           onScriptLoadErrorCallbacks = [];
+          injectionState = INJECTION_STATE_DONE;
         };
 
         script.addEventListener('load', onScriptLoad);


### PR DESCRIPTION
Fix the bug introduced by PR #88.

`injectionState = INJECTION_STATE_DONE` was missing. As a result, the calls to `injectScript`, that happened after the successful/unsuccessful injection, resulted in a promise that was never resolved. Consequently, the component wasn't initialized properly after an unmount + remount.

Adding this line fixes this issue.