### PR TITLE
build: use official typings @types/google.maps

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "rollup-plugin-typescript2": "^0.27.2"
   },
   "dependencies": {
-    "@types/googlemaps": "^3.39.13",
+    "@types/google.maps": "^3.44.1",
     "react-select": "^3.1.0",
     "typescript": "^3.9.7",
     "use-debounce": "^3.4.3"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
     "strictNullChecks": true,
     "suppressImplicitAnyIndexErrors": true,
     "target": "es5",
-    "types": ["googlemaps"]
+    "types": ["google.maps"]
   },
   "include": ["src/**/*"],
   "exclude": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,6 @@
     "strictNullChecks": true,
     "suppressImplicitAnyIndexErrors": true,
     "target": "es5",
-    "types": ["google.maps"]
   },
   "include": ["src/**/*"],
   "exclude": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -198,10 +198,10 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
 
-"@types/googlemaps@^3.39.13":
-  version "3.39.13"
-  resolved "https://registry.yarnpkg.com/@types/googlemaps/-/googlemaps-3.39.13.tgz#a2649ac618cb15bd04ad8700c41693c8c1f90e21"
-  integrity sha512-R/k5WKe8zQHo9oFRINuX/1haKYRkKEfItnBGrSjspbXXITakRdsj6daQIdL1+Pt84lnzduWurxNA5k0fgPMQUg==
+"@types/google.maps@^3.44.1":
+  version "3.44.1"
+  resolved "https://registry.yarnpkg.com/@types/google.maps/-/google.maps-3.44.1.tgz#efe2c6dfaaa9e450b10f35a762e20ec6c4e1fb00"
+  integrity sha512-GV87pp/xSADx/UPeBijOYKbalnuk5iEDg28RV+GuKeqRf6iOxqKrYZPJaKrzl6JdO3QEXuREXu6pwbv4arzTrg==
 
 "@types/json-schema@^7.0.3":
   version "7.0.5"


### PR DESCRIPTION
[`@types/google.maps`](https://www.npmjs.com/package/@types/google.maps) is the [official](https://developers.devsite.corp.google.com/maps/documentation/javascript/using-typescript#getting_started) TypeScript typings for Google Maps JS. These are generated from the internal Google codebase.