### PR TITLE
fix: call initializeService if no apiKey is provided

### DIFF
--- a/src/GooglePlacesAutocomplete.tsx
+++ b/src/GooglePlacesAutocomplete.tsx
@@ -56,6 +56,7 @@ const GooglePlacesAutocomplete: React.FC<GooglePlacesAutocompleteProps> = ({
     }
 
     if (apiKey) init();
+    else initializeService();
   }, []);
 
   return (


### PR DESCRIPTION
Fixes #162 