### PR TITLE
Update GooglePlacesAutocomplete.tsx

### DIFF
--- a/src/GooglePlacesAutocomplete.tsx
+++ b/src/GooglePlacesAutocomplete.tsx
@@ -68,7 +68,7 @@ const GooglePlacesAutocomplete: React.ForwardRefRenderFunction<GooglePlacesAutoc
 
     if (apiKey) init();
     else initializeService();
-  }, []);
+  }, [apiKey, apiOptions, onLoadFailed]);
 
   return (
     <AsyncSelect

--- a/src/GooglePlacesAutocomplete.tsx
+++ b/src/GooglePlacesAutocomplete.tsx
@@ -59,7 +59,7 @@ const GooglePlacesAutocomplete: React.ForwardRefRenderFunction<GooglePlacesAutoc
   useEffect(() => {
     const init = async () => {
       try {
-        await new Loader({ apiKey, ...{ libraries: ['places'], ...apiOptions }}).load();
+        await new Loader({ apiKey, libraries: ['places'], ...apiOptions }).load();
         initializeService();
       } catch (error) {
         onLoadFailed(error);


### PR DESCRIPTION
React Hook React.useEffect has missing dependencies: 'apiKey', 'apiOptions', and 'onLoadError'. Either include them or remove the dependency array. If 'onLoadError' changes too often, find the parent component that defines it and wrap that definition in useCallback