### PR TITLE
Only initialize Places API if necessary

### DIFF
--- a/src/GooglePlacesAutocomplete.tsx
+++ b/src/GooglePlacesAutocomplete.tsx
@@ -59,7 +59,9 @@ const GooglePlacesAutocomplete: React.ForwardRefRenderFunction<GooglePlacesAutoc
   useEffect(() => {
     const init = async () => {
       try {
-        await new Loader({ apiKey, ...{ libraries: ['places'], ...apiOptions }}).load();
+        if ( !window.google || !window.google.maps || !window.google.maps.places ) {
+          await new Loader({ apiKey, ...{ libraries: ['places'], ...apiOptions }}).load();
+        }
         initializeService();
       } catch (error) {
         onLoadFailed(error);


### PR DESCRIPTION
If you render `GooglePlacesAutocomplete` passing `apiKey` as prop, it works great and the script is properly loaded.

However, if you render the component again, a warning is displayed:

```
Aborted attempt to load Google Maps JS with @googlemaps/js-api-loader.This may result in undesirable behavior as script parameters may not match.
```

This happens because the script has already been loaded. The fix is to call `Loader` only if it hasn't been loaded yet.