### PR TITLE
Relax react-select version constraint

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@googlemaps/js-api-loader": "^1.11.1",
     "@types/google.maps": "^3.44.1",
-    "react-select": "^4.1.0",
+    "react-select": "^4.1",
     "typescript": "^3.9.7",
     "use-debounce": "^3.4.3"
   },


### PR DESCRIPTION
Given with semver 4.x should be all new features there's no reason to lock the version to 4.1.x.

This PR simply relaxes the constraint to anything in the 4.x (min 4.1) version range will satisfy the requirement.