### PR TITLE
Add `filterResults` prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ export default Component;
     1. Install [yalc](https://github.com/whitecolor/yalc)
     2. Build project with `yarn build` or `npm run build`
     3. Publish the package with yalc: `yalc publish`
-    4. Add the package to your test project `yalc add react-google-places-automocomplete`
+    4. Add the package to your test project `yalc add react-google-places-autocomplete`
     5. If needed, to update the package on your test project: `yalc update react-google-places-autocomplete`
 
 

--- a/docs/docs/props.md
+++ b/docs/docs/props.md
@@ -6,14 +6,15 @@ sidebar_label: Props
 
 ```tsx
 interface GooglePlacesAutocompleteProps {
-  apiKey?: string;                               // default: ''
-  apiOptions?: ApiOptions;                       // default: { }
-  autocompletionRequest?: AutocompletionRequest; // default: { }
-  debounce?: number;                             // default: 300
-  minLengthAutocomplete?: number;                // default: 0
-  onLoadFailed?: (error: Error) => void;         // default: console.error
-  selectProps?: SelectProps;                     // default: { }
-  withSessionToken?: boolean;                    // default: false
+  apiKey?: string;                                              // default: ''
+  apiOptions?: ApiOptions;                                      // default: { }
+  autocompletionRequest?: AutocompletionRequest;                // default: { }
+  debounce?: number;                                            // default: 300
+  minLengthAutocomplete?: number;                               // default: 0
+  onLoadFailed?: (error: Error) => void;                        // default: console.error
+  selectProps?: SelectProps;                                    // default: { }
+  filterResults?: (results: AutocompletePrediction) => boolean; // default: () => true
+  withSessionToken?: boolean;                                   // default: false
 }
 ```
 
@@ -123,6 +124,18 @@ const [value, setValue] = useState(null);
     value,
     onChange: setValue,
   }}
+/>
+```
+
+## `filterResults`
+
+The Google Place API does not allow you to filter by some attributes of a place, like the `types` response. This optional prop allows you to filter the results that are displayed to the user.
+
+For example, if you only wanted to look for places with a type of `lodging`:
+
+```jsx
+<GooglePlacesAutocomplete
+  filterResults={(result) => result.types.includes('lodging')}
 />
 ```
 

--- a/src/GooglePlacesAutocomplete.tsx
+++ b/src/GooglePlacesAutocomplete.tsx
@@ -16,6 +16,7 @@ const GooglePlacesAutocomplete: React.ForwardRefRenderFunction<GooglePlacesAutoc
   debounce = 300,
   minLengthAutocomplete = 0,
   selectProps = {},
+  filterResults = () => true,
   onLoadFailed = console.error,
   withSessionToken = false,
 } : GooglePlacesAutocompleteProps, ref) : React.ReactElement => {
@@ -33,7 +34,7 @@ const GooglePlacesAutocomplete: React.ForwardRefRenderFunction<GooglePlacesAutoc
         value,
         withSessionToken && sessionToken,
       ), (suggestions) => {
-        cb((suggestions || []).map(suggestion => ({ label: suggestion.description, value: suggestion })));
+        cb((suggestions || []).filter(filterResults).map(suggestion => ({ label: suggestion.description, value: suggestion })));
       },
     );
   }, debounce);

--- a/src/GooglePlacesAutocomplete.types.tsx
+++ b/src/GooglePlacesAutocomplete.types.tsx
@@ -28,5 +28,6 @@ export default interface GooglePlacesAutocompleteProps {
   minLengthAutocomplete?: number;
   onLoadFailed?: (error: Error) => void;
   selectProps?: Props<OptionTypeBase>;
+  filterResults?: (results: google.maps.places.AutocompletePrediction) => boolean;
   withSessionToken?: boolean;
 }


### PR DESCRIPTION
I thought this would be a helpful contribution. Basically, the Google Places API does not allow you to filter by very specific types of places, only general ones (the API can filter by `establishment`, for example, but not `lodging`).

This allows the user to specify whatever filters they'd like to the results before getting passed on react-select.
