### PR TITLE
Change typescript to be a devDependency instead of dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,13 +47,13 @@
     "rollup-plugin-bundle-size": "^1.0.3",
     "rollup-plugin-peer-deps-external": "^2.2.3",
     "rollup-plugin-terser": "^7.0.2",
-    "rollup-plugin-typescript2": "^0.27.2"
+    "rollup-plugin-typescript2": "^0.27.2",
+    "typescript": "^3.9.7"
   },
   "dependencies": {
     "@googlemaps/js-api-loader": "^1.11.1",
     "@types/google.maps": "^3.44.1",
     "react-select": "^4.3.1",
-    "typescript": "^3.9.7",
     "use-debounce": "^3.4.3"
   },
   "peerDependencies": {


### PR DESCRIPTION
Currently, `typescript` package is included in dependencies and this can cause issues if the user of `react-google-places-autocomplete` wants to use their own typescript version. 

- The `node_modules/.bin/tsc` command can end up being directly linked to `/node_modules/react-google-places-autocomplete/node_modules/typescript/bin/tsc` instead of the typescript package that was explicitly included at `node_modules/typescript`.