### PR TITLE
#174 How to specify which data fields to retrieve

### DIFF
--- a/docs/docs/props.md
+++ b/docs/docs/props.md
@@ -65,6 +65,7 @@ interface AutocompletionRequest {
   offset?: number;
   radius?: number;
   types?: string[];
+  fields?: string[];
 }
 ```
 

--- a/src/GooglePlacesAutocomplete.types.tsx
+++ b/src/GooglePlacesAutocomplete.types.tsx
@@ -18,6 +18,7 @@ export interface AutocompletionRequest {
   offset?: number;
   radius?: number;
   types?: string[];
+  fields?: string[];
 }
 
 export default interface GooglePlacesAutocompleteProps {


### PR DESCRIPTION
This change exposes the `fields` property to the `AutocompletionRequest` interface.  This will allow developers to return data like `address_components` in the prediction results according to this example: https://developers.google.com/maps/documentation/javascript/examples/places-autocomplete-addressform