### PR TITLE
Revert "#174 How to specify which data fields to retrieve"

### DIFF
--- a/docs/docs/props.md
+++ b/docs/docs/props.md
@@ -65,7 +65,6 @@ interface AutocompletionRequest {
   offset?: number;
   radius?: number;
   types?: string[];
-  fields?: string[];
 }
 ```
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,7 +19,6 @@ export interface AutocompletionRequest {
   offset?: number;
   radius?: number;
   types?: string[];
-  fields?: string[];
 }
 
 export type Option = {


### PR DESCRIPTION
Reverts Tintef/react-google-places-autocomplete#317

`fields` is not part of the AutocompletionRequest object (reference: https://developers.google.com/maps/documentation/javascript/reference/places-autocomplete-service#AutocompletionRequest)

I think this should be reverted.