### PR TITLE
Remove react 18.3 warning about defaultProps

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@googlemaps/js-api-loader": "^1.14.3",
     "@types/google.maps": "^3.50.4",
-    "react-select": "^5.7.2",
+    "react-select": "^5.7.4",
     "use-debounce": "^3.4.3"
   },
   "peerDependencies": {


### PR DESCRIPTION
react-select dependencies must be updated to 5.7.4 to avoid this annoying warning.