### PR TITLE
Enable Keyboard Accessibility for Custom Menu Items via Option Component

### DIFF
--- a/src/google-places-autocomplete.tsx
+++ b/src/google-places-autocomplete.tsx
@@ -33,6 +33,8 @@ const GooglePlacesAutocomplete: React.ForwardRefRenderFunction<GooglePlacesAutoc
     }
   }), [sessionToken]);
 
+  console.log('TEST')
+
   return (
     <AsyncSelect
       {...args.selectProps ?? {}}

--- a/src/google-places-autocomplete.tsx
+++ b/src/google-places-autocomplete.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useImperativeHandle } from 'react';
+import React, { forwardRef, useImperativeHandle, useCallback } from 'react';
 import AsyncSelect from 'react-select/async';
 
 import GooglePlacesAutocompleteProps, { GooglePlacesAutocompleteHandle } from './types';
@@ -24,6 +24,22 @@ const GooglePlacesAutocomplete: React.ForwardRefRenderFunction<GooglePlacesAutoc
     withSessionToken: args.withSessionToken ?? false,
   });
 
+  // Create combined loadOptions function
+  const combinedLoadOptions = useCallback((inputValue: string, callback: (options: any[]) => void) => {
+    const customSuggestions = args.customSuggestions || [];
+    
+    // Fetch Google Places suggestions
+    fetchSuggestions(inputValue, (googleSuggestions: any[]) => {
+      // Combine custom suggestions with Google suggestions
+      const combinedSuggestions = [
+        ...customSuggestions,
+        ...googleSuggestions
+      ];
+      
+      callback(combinedSuggestions);
+    });
+  }, [fetchSuggestions, args.customSuggestions]);
+
   useImperativeHandle(ref, () => ({
     getSessionToken: () => {
       return sessionToken;
@@ -33,12 +49,10 @@ const GooglePlacesAutocomplete: React.ForwardRefRenderFunction<GooglePlacesAutoc
     }
   }), [sessionToken]);
 
-  console.log('TEST')
-
   return (
     <AsyncSelect
       {...args.selectProps ?? {}}
-      loadOptions={fetchSuggestions}
+      loadOptions={combinedLoadOptions}
       getOptionValue={({ value }) => value.place_id}
     />
   );

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,4 +35,5 @@ export default interface GooglePlacesAutocompleteProps {
   onLoadFailed?: (error: Error) => void;
   selectProps?: AsyncProps<Option, false, GroupBase<Option>>;
   withSessionToken?: boolean;
+  customSuggestions?: Array<Option>;
 }


### PR DESCRIPTION
Previously, when adding custom items—such as a "Use current location" button—to the menu through the MenuList component, these items were not accessible via keyboard navigation, as they were not included in the loadOptions API response. This limited both accessibility and the user experience for any persistent, consumer-defined suggestions shown alongside API-sourced results (such as Google suggestions).

With this PR, we introduce support for adding custom, always-visible menu items using the Option component. Custom suggestions are now fully integrated into the menu's keyboard navigation flow, ensuring they are accessible and selectable via keyboard, regardless of API results. This approach also standardizes how both API-sourced and custom options are managed and rendered.

Key Benefits:

Improved accessibility: Custom menu items are now fully keyboard accessible.

Unified approach: All suggestions—custom and API-based—should now be added via the Option component, not directly through MenuList.

Enhanced flexibility: Easily integrate persistent actions or suggestions (such as "Use current location") while maintaining a consistent user experience.